### PR TITLE
IEM: added Zenodo data download links

### DIFF
--- a/notebooks/iem/iem.ipynb
+++ b/notebooks/iem/iem.ipynb
@@ -51,8 +51,8 @@
    "source": [
     "The data associated with these examples are originally derived from these OSF repositories, but have been sorted and cleaned for easier use.\n",
     "\n",
-    "* Dataset 1 from Rademaker et al. 2019, Nat. Neurosci., stored at https://osf.io/dkx6y/\n",
-    "* Dataset 2 from Itthipuripat et al. 2019, stored at https://osf.io/savfp/"
+    "* Dataset 1 from Rademaker et al. 2019, Nat. Neurosci. [Download here](https://zenodo.org/record/4950267/files/RademakerEtAl2019_WM_S05_avgTime.npz?download=1).\n",
+    "* Dataset 2 from Itthipuripat et al. 2019, J. Neurosci. [Download here](https://zenodo.org/record/4950267/files/AL61_Bilat-V1_attnContrast.mat?download=1).\n"
    ]
   },
   {


### PR DESCRIPTION
@manojneuro Sorry for the delay. The datasets are now uploaded and available at https://zenodo.org/record/4950267.
The individual files are now linked in the notebook.